### PR TITLE
calculating correct frame rate with new timestamps

### DIFF
--- a/brain_observatory_qc/pipeline_dev/calculate_new_dff.py
+++ b/brain_observatory_qc/pipeline_dev/calculate_new_dff.py
@@ -495,7 +495,7 @@ def get_correct_frame_rate(ophys_experiment_id):
 
     Returns:
         float: frame rate
-        pd.DataFrame: timestamps
+        np.array: timestamps
     """
     cache = bpc.from_lims()
     exp = cache.get_behavior_ophys_experiment(ophys_experiment_id)


### PR DESCRIPTION
It seems like to avoid importing old code about Lims_database we can get ophys_timestamps from allen SDK