### PR TITLE
From lims update

### DIFF
--- a/brain_observatory_qc/data_access/from_lims.py
+++ b/brain_observatory_qc/data_access/from_lims.py
@@ -896,29 +896,40 @@ def get_general_info_for_ophys_experiment_id(ophys_experiment_id: int) -> pd.Dat
     Returns
     -------
     DataFrame
-        dataframe with the following columns:
-            ophys_experiment_id
-            ophys_session_id
-            behavior_session_id
-            foraging_id
-            ophys_container_id
-            supercontainer_id
-            experiment_workflow_state
-            session_workflow_state
-            container_workflow_state
-            specimen_id
-            donor_id
-            specimen_name
-            date_of_acquisition
-            session_type
-            targeted_structure
-            depth
-            equipment_name
-            project
-            experiment_storage_directory
-            session_storage_directory
+        table with the following columns:
+            'ophys_experiment_id',
+            'ophys_session_id',
+            'behavior_session_id',
+            'foraging_id',
+            'ophys_container_id',
+            'supercontainer_id',
+            'experiment_workflow_state',
+            'session_workflow_state',
+            'container_workflow_state',
+            'specimen_id',
+            'donor_id',
+            'specimen_name',
+            'date_of_acquisition',
+            'session_type',
+            'targeted_structure',
+            'depth',
+            'equipment_name',
+            'project',
+            'experiment_storage_directory',
+            'behavior_storage_directory',
+            'session_storage_directory',
+            'container_storage_directory',
+            'supercontainer_storage_directory',
+            'specimen_storage_directory'
     """
-    general_info = lims_utils.get_general_info_for_LIMS_imaging_id("ophys_experiment_id", ophys_experiment_id)
+    
+    
+    missing_container = lims_utils.experiment_missing_container(ophys_experiment_id)
+    if missing_container == False:
+        general_info = lims_utils.get_general_info_for_LIMS_imaging_id("ophys_experiment_id", ophys_experiment_id)
+    else:
+        general_info = lims_utils.get_general_info_for_LIMS_imaging_id_no_container("ophys_experiment_id", ophys_experiment_id)
+
     return general_info
 
 

--- a/brain_observatory_qc/data_access/from_lims_utilities.py
+++ b/brain_observatory_qc/data_access/from_lims_utilities.py
@@ -731,9 +731,9 @@ def get_general_info_for_LIMS_imaging_id_no_container(id_type: str, id_number: i
     general_info["container_workflow_state"] = "NA"
     general_info["container_storage_directory"] = "NA"
     general_info["supercontainer_storage_directory"] = "NA"
-
-
     return general_info
+
+
 #####################################################################
 #
 #           FILEPATHS & STORAGE DIRECTORIES
@@ -759,6 +759,8 @@ def correct_LIMS_storage_directory_filepaths(df: pd.DataFrame) -> pd.DataFrame:
     """
     
     storage_directory_columns_list = [col for col in df.columns if 'storage_directory' in col]
+    if "supercontainer_storage_directory" in storage_directory_columns_list:
+        storage_directory_columns_list.remove('supercontainer_storage_directory')
     for column in storage_directory_columns_list:
         df = utils.correct_dataframe_filepath(df, column)
     return df

--- a/brain_observatory_qc/data_access/from_lims_utilities.py
+++ b/brain_observatory_qc/data_access/from_lims_utilities.py
@@ -542,9 +542,6 @@ def get_general_info_for_LIMS_imaging_id(id_type: str, id_number: int) -> pd.Dat
     LEFT JOIN visual_behavior_supercontainers vbs
     ON os.visual_behavior_supercontainer_id = vbs.id
 
-    LEFT JOIN visual_behavior_supercontainers vbs
-    ON os.visual_behavior_supercontainer_id = vbs.id
-
     JOIN projects 		ON projects.id = os.project_id
     JOIN specimens 		ON specimens.id = os.specimen_id
     JOIN structures 	ON structures.id = oe.targeted_structure_id

--- a/brain_observatory_qc/data_access/from_lims_utilities.py
+++ b/brain_observatory_qc/data_access/from_lims_utilities.py
@@ -533,11 +533,14 @@ def get_general_info_for_LIMS_imaging_id(id_type: str, id_number: int) -> pd.Dat
     JOIN behavior_sessions bs
     ON bs.foraging_id = os.foraging_id
 
-    JOIN ophys_experiments_visual_behavior_experiment_containers oevbec
+    LEFT JOIN ophys_experiments_visual_behavior_experiment_containers oevbec
     ON oe.id = oevbec.ophys_experiment_id
 
-    JOIN visual_behavior_experiment_containers vbec
+    LEFT JOIN visual_behavior_experiment_containers vbec
     ON vbec.id = oevbec.visual_behavior_experiment_container_id
+
+    LEFT JOIN visual_behavior_supercontainers vbs
+    ON os.visual_behavior_supercontainer_id = vbs.id
 
     LEFT JOIN visual_behavior_supercontainers vbs
     ON os.visual_behavior_supercontainer_id = vbs.id

--- a/brain_observatory_qc/data_access/utilities.py
+++ b/brain_observatory_qc/data_access/utilities.py
@@ -300,27 +300,12 @@ def correct_filepath(filepath):
     string
         filepath adjusted for users operating system
     """
-    filepath = filepath.replace('/allen', '//allen')
-    corrected_path = Path(filepath)
+    if filepath is None or filepath=="NA" or filepath=="":
+        corrected_path = filepath
+    else:
+        filepath = filepath.replace('/allen', '//allen')
+        corrected_path = Path(filepath)
     return corrected_path
-
-
-def apply_filepath_correction(filepath):
-    """Check if the filepath is empty or 'NA' and apply correction if necessary.
-
-    Parameters
-    ----------
-    filepath : string
-        Given filepath
-
-    Returns
-    -------
-    string
-        Corrected filepath or the original value if it's empty or 'NA'
-    """
-    if pd.isna(filepath) or filepath == "NA" or filepath == "":
-        return filepath
-    return correct_filepath(filepath)
 
 
 def correct_dataframe_filepath(dataframe, column_string):
@@ -342,7 +327,7 @@ def correct_dataframe_filepath(dataframe, column_string):
         returns the input dataframe with the filepath in the given
         column 'corrected' for the users operating system, in place
     """
-    dataframe[column_string] = dataframe[column_string].apply(lambda x: apply_filepath_correction(x))
+    dataframe[column_string] = dataframe[column_string].apply(lambda x: correct_filepath(x))
     return dataframe
 
 

--- a/brain_observatory_qc/data_access/utilities.py
+++ b/brain_observatory_qc/data_access/utilities.py
@@ -285,7 +285,7 @@ def build_tidy_cell_df(session):
     return pd.concat([pd.DataFrame(get_cell_timeseries_dict(session, cell_specimen_id)) for cell_specimen_id in session.dff_traces.reset_index()['cell_specimen_id']]).reset_index(drop=True)
 
 
-def correct_filepath(filepath):
+def correct_filepath(filepath:str)->str:
     """using the pathlib python module, takes in a filepath from an
     arbitrary operating system and returns a filepath that should work
     for the users operating system
@@ -308,7 +308,7 @@ def correct_filepath(filepath):
     return corrected_path
 
 
-def correct_dataframe_filepath(dataframe, column_string):
+def correct_dataframe_filepath(df:pd.DataFrame, column: str) -> pd.DataFrame:
     """applies the correct_filepath function to a given dataframe
     column, replacing the filepath in that column in place
 
@@ -327,8 +327,8 @@ def correct_dataframe_filepath(dataframe, column_string):
         returns the input dataframe with the filepath in the given
         column 'corrected' for the users operating system, in place
     """
-    dataframe[column_string] = dataframe[column_string].apply(lambda x: correct_filepath(x))
-    return dataframe
+    df[column] = df[column].apply(lambda x: correct_filepath(x))
+    return df
 
 
 def dateformat(exp_date):

--- a/brain_observatory_qc/data_access/utilities.py
+++ b/brain_observatory_qc/data_access/utilities.py
@@ -305,6 +305,24 @@ def correct_filepath(filepath):
     return corrected_path
 
 
+def apply_filepath_correction(filepath):
+    """Check if the filepath is empty or 'NA' and apply correction if necessary.
+
+    Parameters
+    ----------
+    filepath : string
+        Given filepath
+
+    Returns
+    -------
+    string
+        Corrected filepath or the original value if it's empty or 'NA'
+    """
+    if pd.isna(filepath) or filepath == "NA" or filepath == "":
+        return filepath
+    return correct_filepath(filepath)
+
+
 def correct_dataframe_filepath(dataframe, column_string):
     """applies the correct_filepath function to a given dataframe
     column, replacing the filepath in that column in place
@@ -324,7 +342,7 @@ def correct_dataframe_filepath(dataframe, column_string):
         returns the input dataframe with the filepath in the given
         column 'corrected' for the users operating system, in place
     """
-    dataframe[column_string] = dataframe[column_string].apply(lambda x: correct_filepath(x))
+    dataframe[column_string] = dataframe[column_string].apply(lambda x: apply_filepath_correction(x))
     return dataframe
 
 


### PR DESCRIPTION
Updates several .py files in the `data_access` module: 
```
from_lims
from_lims_utilities 
utilities
``` 
Updates made were to allow workarounds for getting general info for experiments that do not have a container assigned to them. 

an example of how the new workaround can be done is:
```
import pandas as pd
import from_lims_utilities as lims_utils

c_exp = 1345581430 # id with container
n_exp = 1343780655 # id with no container

missing_container = lims_utils.experiment_missing_container(n_exp)
if missing_container == False:
    general_info = lims_utils.get_general_info_for_LIMS_imaging_id("ophys_experiment_id", n_exp)
else:
    general_info = lims_utils.get_general_info_for_LIMS_imaging_id_no_container("ophys_experiment_id", c_exp)

general_info
```

or the` from_lims.get_general_info_for_ophys_experiment_id` function incorporates that exact logic and should now work with experiments that have containers or not.